### PR TITLE
Bump version to 0.1.3rc1 and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "TerraKit"
-version = "0.1.3rc1"
+version = "0.1.3"
 description = "A Python package for finding and getting geospatial data."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Relax dependency constraints to allow for installation with vllm-tgis-adapter - which is needed for the RedHat build system