### PR TITLE
Pin s3fs==0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "TerraKit"
-version = "0.1.5"
+version = "0.1.6"
 description = "A Python package for finding and getting geospatial data."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -34,7 +34,7 @@ dependencies = [
         "python-dotenv>=1.1.1",
         "rasterio==1.4.3",
         "rioxarray[interp]==0.19.0",
-        "s3fs>=0.4.2,<2024.0.0",
+        "s3fs==0.4.2",
         "scikit-learn>=1.7.1",
         "sentinelhub==3.11.1",
         "shapely>=2.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -4977,7 +4977,7 @@ wheels = [
 
 [[package]]
 name = "terrakit"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -5054,7 +5054,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "rasterio", specifier = "==1.4.3" },
     { name = "rioxarray", extras = ["interp"], specifier = "==0.19.0" },
-    { name = "s3fs", specifier = ">=0.4.2,<2024.0.0" },
+    { name = "s3fs", specifier = "==0.4.2" },
     { name = "scikit-learn", specifier = ">=1.7.1" },
     { name = "sentinelhub", specifier = "==3.11.1" },
     { name = "shapely", specifier = ">=2.1.1" },


### PR DESCRIPTION
Upstream dependency issue persisting:

```
23:35:10 ERROR terrakit: could not handle install dependency aiobotocore<4.0.0,>=2.19.0 (3.2.0) for install dependency s3fs (2026.2.0) for toplevel dependency terrakit (0.1.4) because could not handle install dependency aiobotocore<4.0.0,>=2.19.0 (3.2.0) for install dependency s3fs (2026.2.0) for toplevel dependency terrakit (0.1.4) because could not handle install dependency aiobotocore<4.0.0,>=2.19.0 (3.2.0) for install dependency s3fs (2026.2.0) for toplevel dependency terrakit (0.1.4) because Unable to resolve requirement specifier botocore<1.42.56,>=1.42.53 with constraint botocore==1.42.19 using PyPI resolver (searching at https://pypi.org/simple): found no match for botocore<1.42.56,>=1.42.53 using PyPI resolver (searching at https://pypi.org/simple), searching for sdists, ignoring pre-release versions because found no match for botocore<1.42.56,>=1.42.53 using PyPI resolver (searching at https://pypi.org/simple), searching for sdists, ignoring pre-release versions
```