### PR TITLE
Vulnerability remediate/urlib/click/idna

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
         "boto3>=1.36.0",
         "contextily>=1.6.2",
         "cdsapi>=0.7.7",
+        "click>=8.3.3",
         "dask==2025.7.0",
         "folium>=0.20.0",
         "huggingface-hub",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
         "tacotoolbox==0.5.2",
         "tqdm==4.67.1",
         "xarray>=v2023.1.0 ",
-        "urllib3>=2.6.3",
+        "urllib3>=2.7.0",
         "zarr>=2.18.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
         "huggingface-hub",
         "geojson>=3.2.0",
         "geopandas>=1.1.2",
+        "idna>=3.15",
         "joblib==1.5.2",
         "jsonargparse>=4.40.2",
         "netcdf4>=1.7.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "TerraKit"
-version = "0.1.8"
+version = "0.1.8+hotfix.1"
 description = "A Python package for finding and getting geospatial data."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ hf-xet==1.2.0 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or 
 httpcore==1.0.9
 httpx==0.28.1
 huggingface-hub==1.3.1
-idna==3.11
+idna==3.15
 importlib-metadata==8.7.1 ; python_full_version < '3.12'
 jinja2==3.1.6
 jmespath==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ cdsapi==0.7.7
 certifi==2026.1.4
 cftime==1.6.5
 charset-normalizer==3.4.4
-click==8.3.1
+click==8.4.0
 click-plugins==1.1.1.2
 cligj==0.7.2
 cloudpickle==3.1.2
@@ -124,7 +124,7 @@ typing-extensions==4.15.0
 typing-inspect==0.9.0
 typing-inspection==0.4.2
 tzdata==2025.3
-urllib3==2.6.3
+urllib3==2.7.0
 utm==0.8.1
 wrapt==2.1.1
 xarray==2025.6.1 ; python_full_version < '3.11'

--- a/uv.lock
+++ b/uv.lock
@@ -5266,7 +5266,7 @@ wheels = [
 
 [[package]]
 name = "terrakit"
-version = "0.1.8"
+version = "0.1.8+hotfix.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -688,14 +688,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]
@@ -5272,6 +5272,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },
     { name = "cdsapi" },
+    { name = "click" },
     { name = "contextily" },
     { name = "dask" },
     { name = "folium" },
@@ -5335,6 +5336,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
     { name = "boto3", specifier = ">=1.36.0" },
     { name = "cdsapi", specifier = ">=0.7.7" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "contextily", specifier = ">=1.6.2" },
     { name = "dask", specifier = "==2025.7.0" },
     { name = "folium", specifier = ">=0.20.0" },
@@ -5361,7 +5363,7 @@ requires-dist = [
     { name = "tacoreader", specifier = "==0.5.6" },
     { name = "tacotoolbox", specifier = "==0.5.2" },
     { name = "tqdm", specifier = "==4.67.1" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "xarray", specifier = ">=2023.1.0" },
     { name = "zarr", specifier = ">=2.18.3" },
 ]
@@ -5624,11 +5626,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1672,11 +1672,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -5279,6 +5279,7 @@ dependencies = [
     { name = "geojson" },
     { name = "geopandas" },
     { name = "huggingface-hub" },
+    { name = "idna" },
     { name = "joblib" },
     { name = "jsonargparse" },
     { name = "nest-asyncio" },
@@ -5343,6 +5344,7 @@ requires-dist = [
     { name = "geojson", specifier = ">=3.2.0" },
     { name = "geopandas", specifier = ">=1.1.2" },
     { name = "huggingface-hub" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "joblib", specifier = "==1.5.2" },
     { name = "jsonargparse", specifier = ">=4.40.2" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },


### PR DESCRIPTION
<details><summary><img src='https://whitesource-resources.whitesourcesoftware.com/vulnerability_details.png' width=19 height=20> Vulnerable Library - <b>click-8.3.1-py3-none-any.whl</b></summary>

<p>Composable command line interface toolkit</p>
<p>Library home page: <a href="https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl">https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl</a></p>
<p>Path to dependency file: /requirements.txt</p>
<p>Path to vulnerable library: /tmp/ws-ua_20260427211237_PWPDZP/python_CYDALI/20260427211246/click-8.3.1-py3-none-any.whl</p>
<p>

</details>

## Vulnerabilities

| Vulnerability | Severity | <img src='https://whitesource-resources.whitesourcesoftware.com/cvss3.png' width=19 height=20> CVSS | Dependency | Type | Fixed in (click version) | Remediation Possible** |
| ------------- | ------------- | ----- | ----- | ----- | ------------- | --- |
| [CVE-2026-7246](https://www.mend.io/vulnerability-database/CVE-2026-7246) | <img src='https://whitesource-resources.whitesourcesoftware.com/high_vul.png?' width=19 height=20> High | 7.2 | click-8.3.1-py3-none-any.whl | Direct | https://github.com/pallets/click.git - 8.3.3,click - 8.3.3 | &#9989; |
<p>**In some cases, Remediation PR cannot be created automatically for a vulnerability despite the availability of remediation</p>

## Details

<details>

<summary><img src='https://whitesource-resources.whitesourcesoftware.com/high_vul.png?' width=19 height=20> CVE-2026-7246</summary>


###  Vulnerable Library - <b>click-8.3.1-py3-none-any.whl</b>

<p>Composable command line interface toolkit</p>
<p>Library home page: <a href="https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl">https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl</a></p>
<p>Path to dependency file: /requirements.txt</p>
<p>Path to vulnerable library: /tmp/ws-ua_20260427211237_PWPDZP/python_CYDALI/20260427211246/click-8.3.1-py3-none-any.whl</p>
<p>

Dependency Hierarchy:
  - :x: **click-8.3.1-py3-none-any.whl** (Vulnerable Library)
<p>Found in base branch: <b>main</b></p>
</p>

<p></p>

###  Vulnerability Details
<p>  
  
Pallets Click, versions 8.3.2 and below, contain a command injection vulnerability in the click.edit() function, allowing attackers to pass arbitrary OS commands from an unprivileged account.
 Mend Note: The description of this vulnerability differs from MITRE. 

<p>Publish Date: 2026-04-30
<p>URL: <a href=https://www.mend.io/vulnerability-database/CVE-2026-7246>CVE-2026-7246</a></p>
</p>

<p></p>

###  CVSS 3 Score Details (<b>7.2</b>)
<p>

Base Score Metrics:
- Exploitability Metrics:
  - Attack Vector: Local
  - Attack Complexity: High
  - Privileges Required: High
  - User Interaction: Required
  - Scope: Changed
- Impact Metrics:
  - Confidentiality Impact: High
  - Integrity Impact: High
  - Availability Impact: High
</p>
For more information on CVSS3 Scores, click <a href="https://www.first.org/cvss/calculator/3.0">here</a>.
</p>

<p></p>

###  Suggested Fix
<p>

<p>Type: Upgrade version</p>
<p>Origin: <a href="https://github.com/pallets/click/commit/b96c2601af4e01341b4d2c0db494ebee4aef8f42">https://github.com/pallets/click/commit/b96c2601af4e01341b4d2c0db494ebee4aef8f42</a></p>
<p>Release Date: 2026-04-30</p>
<p>Fix Resolution: https://github.com/pallets/click.git - 8.3.3,click - 8.3.3</p>

</p>

<p></p>
</details>

<details><summary><img src='https://whitesource-resources.whitesourcesoftware.com/vulnerability_details.png' width=19 height=20> Vulnerable Library - <b>click-8.3.1-py3-none-any.whl</b></summary>

<p>Composable command line interface toolkit</p>
<p>Library home page: <a href="https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl">https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl</a></p>
<p>Path to dependency file: /requirements.txt</p>
<p>Path to vulnerable library: /tmp/ws-ua_20260427211237_PWPDZP/python_CYDALI/20260427211246/click-8.3.1-py3-none-any.whl</p>
<p>

</details>

## Vulnerabilities

| Vulnerability | Severity | <img src='https://whitesource-resources.whitesourcesoftware.com/cvss3.png' width=19 height=20> CVSS | Dependency | Type | Fixed in (click version) | Remediation Possible** |
| ------------- | ------------- | ----- | ----- | ----- | ------------- | --- |
| [CVE-2026-7246](https://www.mend.io/vulnerability-database/CVE-2026-7246) | <img src='https://whitesource-resources.whitesourcesoftware.com/high_vul.png?' width=19 height=20> High | 7.2 | click-8.3.1-py3-none-any.whl | Direct | https://github.com/pallets/click.git - 8.3.3,click - 8.3.3 | &#9989; |
<p>**In some cases, Remediation PR cannot be created automatically for a vulnerability despite the availability of remediation</p>

## Details

<details>

<summary><img src='https://whitesource-resources.whitesourcesoftware.com/high_vul.png?' width=19 height=20> CVE-2026-7246</summary>


###  Vulnerable Library - <b>click-8.3.1-py3-none-any.whl</b>

<p>Composable command line interface toolkit</p>
<p>Library home page: <a href="https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl">https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl</a></p>
<p>Path to dependency file: /requirements.txt</p>
<p>Path to vulnerable library: /tmp/ws-ua_20260427211237_PWPDZP/python_CYDALI/20260427211246/click-8.3.1-py3-none-any.whl</p>
<p>

Dependency Hierarchy:
  - :x: **click-8.3.1-py3-none-any.whl** (Vulnerable Library)
<p>Found in base branch: <b>main</b></p>
</p>

<p></p>

###  Vulnerability Details
<p>  
  
Pallets Click, versions 8.3.2 and below, contain a command injection vulnerability in the click.edit() function, allowing attackers to pass arbitrary OS commands from an unprivileged account.
 Mend Note: The description of this vulnerability differs from MITRE. 

<p>Publish Date: 2026-04-30
<p>URL: <a href=https://www.mend.io/vulnerability-database/CVE-2026-7246>CVE-2026-7246</a></p>
</p>

<p></p>

###  CVSS 3 Score Details (<b>7.2</b>)
<p>

Base Score Metrics:
- Exploitability Metrics:
  - Attack Vector: Local
  - Attack Complexity: High
  - Privileges Required: High
  - User Interaction: Required
  - Scope: Changed
- Impact Metrics:
  - Confidentiality Impact: High
  - Integrity Impact: High
  - Availability Impact: High
</p>
For more information on CVSS3 Scores, click <a href="https://www.first.org/cvss/calculator/3.0">here</a>.
</p>

<p></p>

###  Suggested Fix
<p>

<p>Type: Upgrade version</p>
<p>Origin: <a href="https://github.com/pallets/click/commit/b96c2601af4e01341b4d2c0db494ebee4aef8f42">https://github.com/pallets/click/commit/b96c2601af4e01341b4d2c0db494ebee4aef8f42</a></p>
<p>Release Date: 2026-04-30</p>
<p>Fix Resolution: https://github.com/pallets/click.git - 8.3.3,click - 8.3.3</p>

</p>

<p></p>
</details>

<details><summary><img src='https://whitesource-resources.whitesourcesoftware.com/vulnerability_details.png' width=19 height=20> Vulnerable Library - <b>idna-3.11-py3-none-any.whl</b></summary>

<p>Internationalized Domain Names in Applications (IDNA)</p>
<p>Library home page: <a href="https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl">https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl</a></p>
<p>Path to dependency file: /requirements.txt</p>
<p>Path to vulnerable library: /tmp/ws-ua_20260427211237_PWPDZP/python_CYDALI/20260427211246/idna-3.11-py3-none-any.whl</p>
<p>

</details>

## Vulnerabilities

| Vulnerability | Severity | <img src='https://whitesource-resources.whitesourcesoftware.com/cvss3.png' width=19 height=20> CVSS | Dependency | Type | Fixed in (idna version) | Remediation Possible** |
| ------------- | ------------- | ----- | ----- | ----- | ------------- | --- |
| [CVE-2026-45409](https://www.mend.io/vulnerability-database/CVE-2026-45409) | <img src='https://whitesource-resources.whitesourcesoftware.com/medium_vul.png?' width=19 height=20> Medium | 5.3 | idna-3.11-py3-none-any.whl | Direct | idna - 3.15 | &#10060; |
<p>**In some cases, Remediation PR cannot be created automatically for a vulnerability despite the availability of remediation</p>

## Details

<details>

<summary><img src='https://whitesource-resources.whitesourcesoftware.com/medium_vul.png?' width=19 height=20> CVE-2026-45409</summary>


###  Vulnerable Library - <b>idna-3.11-py3-none-any.whl</b>

<p>Internationalized Domain Names in Applications (IDNA)</p>
<p>Library home page: <a href="https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl">https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl</a></p>
<p>Path to dependency file: /requirements.txt</p>
<p>Path to vulnerable library: /tmp/ws-ua_20260427211237_PWPDZP/python_CYDALI/20260427211246/idna-3.11-py3-none-any.whl</p>
<p>

Dependency Hierarchy:
  - :x: **idna-3.11-py3-none-any.whl** (Vulnerable Library)
<p>Found in base branch: <b>main</b></p>
</p>

<p></p>

###  Vulnerability Details
<p>  
  
This is the same issue as CVE-2024-3651, however the original remediation in 2024 was not a complete fix. Payloads such as ""\u0660" * N" or ""\u30fb" * N + "\u6f22"" utilize the "valid_contexto" function prior to length rejection, and for high values of "N" will take a long time to process. Impact A specially crafted argument to the "idna.encode()" function could consume significant resources. This may lead to a denial-of-service. Patches Starting in version 3.14, the function rejects long inputs as soon as practicable prior to any further processing to minimize resource consumption. In version 3.15, this approach was extended to lesser used alternate functions (i.e. per-label conversions and codec support). Workarounds Domain names cannot exceed 253 characters in length, if this length limit is enforced prior to passing the domain to the "idna.encode()" function it should no longer consume significant resources. This is triggered by arbitrarily large inputs that would not occur in normal usage, but may be passed to the library assuming there is no preliminary input validation by the higher-level application.

<p>Publish Date: 2026-05-19
<p>URL: <a href=https://www.mend.io/vulnerability-database/CVE-2026-45409>CVE-2026-45409</a></p>
</p>

<p></p>

###  CVSS 3 Score Details (<b>5.3</b>)
<p>

Base Score Metrics:
- Exploitability Metrics:
  - Attack Vector: Network
  - Attack Complexity: Low
  - Privileges Required: None
  - User Interaction: None
  - Scope: Unchanged
- Impact Metrics:
  - Confidentiality Impact: None
  - Integrity Impact: None
  - Availability Impact: Low
</p>
For more information on CVSS3 Scores, click <a href="https://www.first.org/cvss/calculator/3.0">here</a>.
</p>

<p></p>

###  Suggested Fix
<p>

<p>Type: Upgrade version</p>
<p>Origin: <a href="https://github.com/advisories/GHSA-65pc-fj4g-8rjx">https://github.com/advisories/GHSA-65pc-fj4g-8rjx</a></p>
<p>Release Date: 2026-05-19</p>
<p>Fix Resolution: idna - 3.15</p>

</p>

<p></p>

</details>


<details><summary><img src='https://whitesource-resources.whitesourcesoftware.com/vulnerability_details.png' width=19 height=20> Vulnerable Library - <b>idna-3.11-py3-none-any.whl</b></summary>

<p>Internationalized Domain Names in Applications (IDNA)</p>
<p>Library home page: <a href="https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl">https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl</a></p>
<p>Path to dependency file: /requirements.txt</p>
<p>Path to vulnerable library: /tmp/ws-ua_20260427211237_PWPDZP/python_CYDALI/20260427211246/idna-3.11-py3-none-any.whl</p>
<p>

</details>